### PR TITLE
Handle percent encoded ampersand correctly in values

### DIFF
--- a/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
@@ -55,9 +55,6 @@ final class URLEncodedFormParser {
                 if omitFlags {
                     continue
                 }
-                guard let decodedKey = decodedKey else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
-                }
                 key = try parseKey(data: decodedKey)
                 data = "true"
             } else {

--- a/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
@@ -55,6 +55,9 @@ final class URLEncodedFormParser {
                 if omitFlags {
                     continue
                 }
+                guard let decodedKey = decodedKey else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
+                }
                 key = try parseKey(data: decodedKey)
                 data = "true"
             } else {

--- a/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
@@ -40,16 +40,22 @@ final class URLEncodedFormParser {
                 if omitEmptyValues && token[1].count == 0 {
                     continue
                 }
-                key = try parseKey(data: token[0])
-                guard let decoded = try token[1].utf8DecodedString().removingPercentEncoding else {
+                guard let decodedKey = try token[0].utf8DecodedString().removingPercentEncoding else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[0])")
+                }
+                key = try parseKey(data: decodedKey)
+                guard let decodedValue = try token[1].utf8DecodedString().removingPercentEncoding else {
                     throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[1])")
                 }
-                data = .str(decoded)
+                data = .str(decodedValue)
             } else if token.count == 1 {
                 if omitFlags {
                     continue
                 }
-                key = try parseKey(data: token[0])
+                guard let decodedKey = try token[0].utf8DecodedString().removingPercentEncoding else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[0])")
+                }
+                key = try parseKey(data: decodedKey)
                 data = "true"
             } else {
                 throw URLEncodedFormError(
@@ -75,7 +81,8 @@ final class URLEncodedFormParser {
     }
 
     /// Parses a `URLEncodedFormEncodedKey` from `Data`.
-    private func parseKey(data: Data) throws -> URLEncodedFormEncodedKey {
+    private func parseKey(data dataConvertible: LosslessDataConvertible) throws -> URLEncodedFormEncodedKey {
+        let data = dataConvertible.convertToData()
         let stringData: Data
         let subKeys: [URLEncodedFormEncodedSubKey]
 

--- a/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
@@ -36,24 +36,27 @@ final class URLEncodedFormParser {
                 omittingEmptySubsequences: false
             )
 
+            let decodedKey = try token.first?.utf8DecodedString().removingPercentEncoding
+            let decodedValue = try token.last?.utf8DecodedString().removingPercentEncoding
+
             if token.count == 2 {
                 if omitEmptyValues && token[1].count == 0 {
                     continue
                 }
-                guard let decodedKey = try token[0].utf8DecodedString().removingPercentEncoding else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[0])")
+                guard let decodedKey = decodedKey else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
+                }
+                guard let decodedValue = decodedValue else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string value: \(token[1])")
                 }
                 key = try parseKey(data: decodedKey)
-                guard let decodedValue = try token[1].utf8DecodedString().removingPercentEncoding else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[1])")
-                }
                 data = .str(decodedValue)
             } else if token.count == 1 {
                 if omitFlags {
                     continue
                 }
-                guard let decodedKey = try token[0].utf8DecodedString().removingPercentEncoding else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string: \(token[0])")
+                guard let decodedKey = decodedKey else {
+                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
                 }
                 key = try parseKey(data: decodedKey)
                 data = "true"

--- a/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormParser.swift
@@ -36,15 +36,17 @@ final class URLEncodedFormParser {
                 omittingEmptySubsequences: false
             )
 
-            let decodedKey = try token.first?.utf8DecodedString().removingPercentEncoding
+            guard let decodedKey = try token.first?.utf8DecodedString().removingPercentEncoding else {
+                throw URLEncodedFormError(
+                    identifier: "percentDecoding",
+                    reason: "Could not percent decode string key: \(token[0])"
+                )
+            }
             let decodedValue = try token.last?.utf8DecodedString().removingPercentEncoding
 
             if token.count == 2 {
                 if omitEmptyValues && token[1].count == 0 {
                     continue
-                }
-                guard let decodedKey = decodedKey else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
                 }
                 guard let decodedValue = decodedValue else {
                     throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string value: \(token[1])")
@@ -54,9 +56,6 @@ final class URLEncodedFormParser {
             } else if token.count == 1 {
                 if omitFlags {
                     continue
-                }
-                guard let decodedKey = decodedKey else {
-                    throw URLEncodedFormError(identifier: "percentDecoding", reason: "Could not percent decode string key: \(token[0])")
                 }
                 key = try parseKey(data: decodedKey)
                 data = "true"

--- a/Tests/URLEncodedFormTests/URLEncodedFormParserTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormParserTests.swift
@@ -7,6 +7,12 @@ class URLEncodedFormParserTests: XCTestCase {
         let form = try URLEncodedFormParser.default.parse(data: data)
         XCTAssertEqual(form, ["hello": "world", "foo": "bar"])
     }
+    
+    func testBasicWithAmpersand() throws {
+        let data = "hello=world&foo=bar%26bar".data(using: .utf8)!
+        let form = try URLEncodedFormParser.default.parse(data: data)
+        XCTAssertEqual(form, ["hello": "world", "foo": "bar&bar"])
+    }
 
     func testDictionary() throws {
         let data = "greeting[en]=hello&greeting[es]=hola".data(using: .utf8)!
@@ -47,6 +53,7 @@ class URLEncodedFormParserTests: XCTestCase {
 
     static let allTests = [
         ("testBasic", testBasic),
+        ("testBasicWithAmpersand", testBasicWithAmpersand),
         ("testDictionary", testDictionary),
         ("testArray", testArray),
         ("testOptions", testOptions),

--- a/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
@@ -8,6 +8,12 @@ class URLEncodedFormSerializerTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa%5D=%2Bbbb%20%20ccc")
     }
 
+    func testPercentEncodingWithAmpersand() throws {
+        let form: [String: URLEncodedFormData] = ["aaa": "b%26&b"]
+        let data = try URLEncodedFormSerializer.default.serialize(form)
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526&b")
+    }
+
     func testNested() throws {
         let form: [String: URLEncodedFormData] = ["a": ["b": ["c": ["d": ["hello": "world"]]]]]
         let data = try URLEncodedFormSerializer.default.serialize(form)
@@ -16,6 +22,7 @@ class URLEncodedFormSerializerTests: XCTestCase {
 
     static let allTests = [
         ("testPercentEncoding", testPercentEncoding),
+        ("testPercentEncodingWithAmpersand", testPercentEncodingWithAmpersand),
         ("testNested", testNested),
     ]
 }


### PR DESCRIPTION
Handle ampersand when it's not used as separator but as part of an url-encoded value `%26` (e.g: `ab%26cd` => `ab&cd`)

Fixes https://github.com/vapor/vapor/issues/1655

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.

cc @tanner0101 