### PR TITLE
Add support for sorted keys.

### DIFF
--- a/Sources/URLEncodedForm/Codable/URLEncodedFormEncoder.swift
+++ b/Sources/URLEncodedForm/Codable/URLEncodedFormEncoder.swift
@@ -24,7 +24,8 @@ public final class URLEncodedFormEncoder: DataEncoder {
         /// Produce output with dictionary keys sorted in lexicographic order.
         public static let sortedKeys = OutputFormatting(rawValue: 1 << 1)
     }
-    
+
+    /// The output format to produce. Defaults to `[]`.
     public var outputFormatting: OutputFormatting = []
     
     /// Create a new `URLEncodedFormEncoder`.

--- a/Sources/URLEncodedForm/Codable/URLEncodedFormEncoder.swift
+++ b/Sources/URLEncodedForm/Codable/URLEncodedFormEncoder.swift
@@ -11,6 +11,22 @@
 /// See [Mozilla's](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST) docs for more information about
 /// url-encoded forms.
 public final class URLEncodedFormEncoder: DataEncoder {
+    /// The formatting of the output data.
+    public struct OutputFormatting : OptionSet {
+        /// The format's default value.
+        public let rawValue: UInt
+        
+        /// Creates an OutputFormatting value with the given raw value.
+        public init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+        
+        /// Produce output with dictionary keys sorted in lexicographic order.
+        public static let sortedKeys = OutputFormatting(rawValue: 1 << 1)
+    }
+    
+    public var outputFormatting: OutputFormatting = []
+    
     /// Create a new `URLEncodedFormEncoder`.
     public init() {}
 
@@ -28,7 +44,7 @@ public final class URLEncodedFormEncoder: DataEncoder {
         let context = URLEncodedFormDataContext(.dict([:]))
         let encoder = _URLEncodedFormEncoder(context: context, codingPath: [])
         try encodable.encode(to: encoder)
-        let serializer = URLEncodedFormSerializer()
+        let serializer = URLEncodedFormSerializer(sortedKeys: self.outputFormatting.contains(.sortedKeys))
         guard case .dict(let dict) = context.data else {
             throw URLEncodedFormError(
                 identifier: "invalidTopLevel",

--- a/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
@@ -3,19 +3,37 @@ import Bits
 /// Converts `[String: URLEncodedFormData]` structs to `Data`.
 final class URLEncodedFormSerializer {
     /// Default form url encoded serializer.
-    static let `default` = URLEncodedFormSerializer()
+    static let `default` = URLEncodedFormSerializer(sortedKeys: false)
+    
+    private var sortedKeys: Bool
 
     /// Create a new form-urlencoded data serializer.
-    init() {}
+    init(sortedKeys: Bool) {
+        self.sortedKeys = sortedKeys
+    }
 
     /// Serializes the data.
     func serialize(_ URLEncodedFormEncoded: [String: URLEncodedFormData]) throws -> Data {
         var data: [Data] = []
-        for (key, val) in URLEncodedFormEncoded {
-            let key = try key.urlEncodedFormEncoded()
-            let subdata = try serialize(val, forKey: key)
-            data.append(subdata)
+        
+        if self.sortedKeys {
+            let elements = URLEncodedFormEncoded.sorted { (left, right) -> Bool in
+                return left.key.compare(right.key, options: [.numeric, .caseInsensitive, .forcedOrdering]) == .orderedAscending
+            }
+            
+            for (key, val) in elements {
+                let key = try key.urlEncodedFormEncoded()
+                let subdata = try serialize(val, forKey: key)
+                data.append(subdata)
+            }
+        } else {
+            for (key, val) in URLEncodedFormEncoded {
+                let key = try key.urlEncodedFormEncoded()
+                let subdata = try serialize(val, forKey: key)
+                data.append(subdata)
+            }
         }
+        
         return data.joinedWithAmpersands()
     }
 

--- a/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
@@ -5,6 +5,7 @@ final class URLEncodedFormSerializer {
     /// Default form url encoded serializer.
     static let `default` = URLEncodedFormSerializer(sortedKeys: false)
     
+    /// Produce JSON with dictionary keys sorted in lexicographic order.
     private var sortedKeys: Bool
 
     /// Create a new form-urlencoded data serializer.
@@ -15,25 +16,22 @@ final class URLEncodedFormSerializer {
     /// Serializes the data.
     func serialize(_ URLEncodedFormEncoded: [String: URLEncodedFormData]) throws -> Data {
         var data: [Data] = []
-        
+        var elements: [(key: String, value: URLEncodedFormData)]!
+
         if self.sortedKeys {
-            let elements = URLEncodedFormEncoded.sorted { (left, right) -> Bool in
+            elements = URLEncodedFormEncoded.sorted { (left, right) -> Bool in
                 return left.key.compare(right.key, options: [.numeric, .caseInsensitive, .forcedOrdering]) == .orderedAscending
             }
-            
-            for (key, val) in elements {
-                let key = try key.urlEncodedFormEncoded()
-                let subdata = try serialize(val, forKey: key)
-                data.append(subdata)
-            }
         } else {
-            for (key, val) in URLEncodedFormEncoded {
-                let key = try key.urlEncodedFormEncoded()
-                let subdata = try serialize(val, forKey: key)
-                data.append(subdata)
-            }
+            elements = URLEncodedFormEncoded.map { $0 }
         }
-        
+
+        for (key, val) in elements {
+            let key = try key.urlEncodedFormEncoded()
+            let subdata = try serialize(val, forKey: key)
+            data.append(subdata)
+        }
+
         return data.joinedWithAmpersands()
     }
 
@@ -50,10 +48,21 @@ final class URLEncodedFormSerializer {
 
     /// Serializes a `[String: URLEncodedFormData]` at a given key.
     private func serialize(_ dictionary: [String: URLEncodedFormData], forKey key: Data) throws -> Data {
-        let values = try dictionary.map { subKey, value -> Data in
+        var elements: [(key: String, value: URLEncodedFormData)]!
+
+        if self.sortedKeys {
+            elements = dictionary.sorted { (left, right) -> Bool in
+                return left.key.compare(right.key, options: [.numeric, .caseInsensitive, .forcedOrdering]) == .orderedAscending
+            }
+        } else {
+            elements = dictionary.map { $0 }
+        }
+
+        let values = try elements.map { (subKey, value) -> Data in
             let keyPath = try [.leftSquareBracket] + subKey.urlEncodedFormEncoded() + [.rightSquareBracket]
             return try serialize(value, forKey: key + keyPath)
         }
+
         return values.joinedWithAmpersands()
     }
 

--- a/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
@@ -86,6 +86,7 @@ class URLEncodedFormCodableTests: XCTestCase {
         ("testCodable", testCodable),
         ("testDecodeIntArray", testDecodeIntArray),
         ("testRawEnum", testRawEnum),
+        ("testSortedDictionary", testSortedDictionary),
         ("testGH3", testGH3),
     ]
 }

--- a/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
@@ -62,6 +62,15 @@ class URLEncodedFormCodableTests: XCTestCase {
         XCTAssertEqual(string?.contains("type=cat"), true)
     }
 
+    func testSortedDictionary() throws {
+        let user = User(name: "Tanner", age: 23, pets: ["Zizek", "Foo"], dict: ["a": 1, "b": 2])
+        let encoder = URLEncodedFormEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try encoder.encode(user)
+        let string = String(data: data, encoding: .ascii)
+        XCTAssertEqual(string, "age=23&dict[a]=1&dict[b]=2&name=Tanner&pets[]=Zizek&pets[]=Foo")
+    }
+
     /// https://github.com/vapor/url-encoded-form/issues/3
     func testGH3() throws {
         struct Foo: Codable {


### PR DESCRIPTION
Swift on macOS and Linux have different dictionary enumeration algorithms that lead to non-deterministic encoding output, which breaks testing.  

Mimicking JSONSerialization (see https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/JSONSerialization.swift), we must offer support to sort dictionary keys in order to guarantee output consistency.