### PR TITLE
Percent-escape ampersands in serialization

### DIFF
--- a/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
@@ -79,5 +79,6 @@ private var _allowedCharacters: CharacterSet = {
     var allowed = CharacterSet.urlQueryAllowed
     allowed.remove("+")
     allowed.remove("&")
+    allowed.remove(";")
     return allowed
 }()

--- a/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
@@ -78,5 +78,6 @@ private extension String {
 private var _allowedCharacters: CharacterSet = {
     var allowed = CharacterSet.urlQueryAllowed
     allowed.remove("+")
+    allowed.remove("&")
     return allowed
 }()

--- a/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
@@ -11,7 +11,7 @@ class URLEncodedFormSerializerTests: XCTestCase {
     func testPercentEncodingWithAmpersand() throws {
         let form: [String: URLEncodedFormData] = ["aaa": "b%26&b"]
         let data = try URLEncodedFormSerializer.default.serialize(form)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526&b")
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526%26b")
     }
 
     func testNested() throws {


### PR DESCRIPTION
I believe ampersands should be percent-encoded during serialization so they're not regarded as separators.