### PR TITLE
Mimic reference implementations for serialization

### DIFF
--- a/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
@@ -5,13 +5,13 @@ class URLEncodedFormSerializerTests: XCTestCase {
     func testPercentEncoding() throws {
         let form: [String: URLEncodedFormData] = ["aaa]": "+bbb  ccc"]
         let data = try URLEncodedFormSerializer.default.serialize(form)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa%5D=%2Bbbb%20%20ccc")
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa%5D=%2Bbbb++ccc")
     }
 
     func testPercentEncodingWithAmpersand() throws {
         let form: [String: URLEncodedFormData] = ["aaa": "b%26&b"]
         let data = try URLEncodedFormSerializer.default.serialize(form)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526&b")
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526%26b")
     }
 
     func testNested() throws {


### PR DESCRIPTION
According to RFC 1866, space characters are replaced by `+` and reserved characters are escaped. “Reserved characters” here means all non-alphanumeric characters. However, some characters are treated as safe in most implementations. WebKit, Blink and Gecko all preserve the following characters:
* `*` (U+002A)
* `-` (U+002D)
* `.` (U+002E)
* `_` (U+005F)

Reference:
* [W3C: Forms](https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1)
* [RFC 1866](https://tools.ietf.org/html/rfc1866#section-8.2.1)

Reference implementations:
* [WebKit](https://github.com/WebKit/webkit/blob/bb2f61c40aa613b1b3282ac8d86323d10571c8e8/Source/WTF/wtf/URLParser.cpp#L2816)
* [Blink](https://github.com/chromium/chromium/blob/d3c04350e194839ab4b708f8f906467dba4ecb8f/third_party/blink/renderer/platform/network/form_data_encoder.cc#L226)
* [Gecko](https://github.com/mozilla/gecko/blob/0e0308d10a5fd4a8dcf0601978776342a2abf2df/dom/url/URLSearchParams.cpp#L263)