### PR TITLE
Encode reserved characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /*.xcodeproj
 Package.resolved
 DerivedData
+.swiftpm
+

--- a/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
+++ b/Sources/URLEncodedForm/Data/URLEncodedFormSerializer.swift
@@ -77,6 +77,6 @@ private extension String {
 /// Characters allowed in form-urlencoded data.
 private var _allowedCharacters: CharacterSet = {
     var allowed = CharacterSet.urlQueryAllowed
-    allowed.remove("+")
+    allowed.remove(charactersIn: "?&=[];+")
     return allowed
 }()

--- a/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormCodableTests.swift
@@ -76,6 +76,16 @@ class URLEncodedFormCodableTests: XCTestCase {
         XCTAssertEqual(foo.flag, true)
     }
 
+    /// https://github.com/vapor/url-encoded-form/issues/3
+    func testEncodeReserved() throws {
+        struct Foo: Codable {
+            var reserved: String
+        }
+        let foo = Foo(reserved: "?&=[];+")
+        let data = try URLEncodedFormEncoder().encode(foo)
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "reserved=%3F%26%3D%5B%5D%3B%2B")
+    }
+
     static let allTests = [
         ("testDecode", testDecode),
         ("testEncode", testEncode),
@@ -83,6 +93,7 @@ class URLEncodedFormCodableTests: XCTestCase {
         ("testDecodeIntArray", testDecodeIntArray),
         ("testRawEnum", testRawEnum),
         ("testGH3", testGH3),
+        ("testEncodeReserved", testEncodeReserved),
     ]
 }
 

--- a/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
+++ b/Tests/URLEncodedFormTests/URLEncodedFormSerializerTests.swift
@@ -11,7 +11,7 @@ class URLEncodedFormSerializerTests: XCTestCase {
     func testPercentEncodingWithAmpersand() throws {
         let form: [String: URLEncodedFormData] = ["aaa": "b%26&b"]
         let data = try URLEncodedFormSerializer.default.serialize(form)
-        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526&b")
+        XCTAssertEqual(String(data: data, encoding: .utf8)!, "aaa=b%2526%26b")
     }
 
     func testNested() throws {

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - run:
           name: Clone Vapor
-          command: git clone -b master https://github.com/vapor/vapor.git
+          command: git clone -b 3 https://github.com/vapor/vapor.git
           working_directory: ~/
       - run:
           name: Switch Vapor to this URLEncodedForm revision


### PR DESCRIPTION
Fixes https://github.com/vapor/url-encoded-form/issues/18. Encodes reserved characters like `&` in URL-encoded form keys and values. 